### PR TITLE
Create bootloader build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: X16 SMC bootloader build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install build enviroment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make build-essential
+          git clone https://github.com/Ro5bert/avra.git
+          cd avra
+          make
+          sudo make install 
+          cd ..
+
+      - name: Install IntelHex library
+        run: pip install intelhex
+ 
+      - name: Compile bootloader
+        run: |
+          make
+
+      - name: Archive bootloader
+        uses: actions/upload-artifact@v4
+        with:
+          name: SMC bootloader
+          path: |
+            build/bootloader.hex
+            build/bootloader.bin

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ $(BUILD_DIR)/bootloader.hex: $(SRC_FILES)
 	avra -o $@ -W NoRegDef main.asm
 	rm -f main.eep.hex	
 	rm -f main.obj
-	python scripts/merge_firmware_and_bootloader.py
 	python scripts/convert_hex2bin.py
  
 # Clean


### PR DESCRIPTION
Creates a Github build action for the bootloader.

It also doesn't call the script "merge_firmware_and_bootloader.py" from Makefile, as merging the firmware and the bootloader is a job for the x16-smc build action.

Later on, that script should be deleted entirely from this project, but I propose to keep it here until implemented in the x16-smc project.