### PR TITLE
Ban value 0x8a at start of the bootloader

### DIFF
--- a/scripts/convert_hex2bin.py
+++ b/scripts/convert_hex2bin.py
@@ -6,8 +6,15 @@ bootloader.fromfile("build/bootloader.hex", format="hex")
 bootloader[0] = 0x8a
 
 # Validate start of bootloader != 0x8a
+#   Before bootloader v3, 0x1e00 was set to the magic value 0x8a to indicate that
+#   a bootloader was present. From bootloader v3 the magic value and version
+#   number has been moved to the end of flash memory (0x1ffe-0x1fff).
+#   The start of the bootloader is expected to be a table of rjmp instructions.
+#   There is one rjmp instruction with a target address within the bootloader area
+#   where the low byte is 0x8a. This rjmp instruction should consequently be avoided.
+#   This script exits with an error code to remind us about the above.
 if bootloader[0] == 0x8a:
-    print("Error: Bootloader may not start with byte value 0x8a")
+    print("ERROR: The bootloader may not start with byte value 0x8a.")
     exit(1)
 
 # Create bin file

--- a/scripts/convert_hex2bin.py
+++ b/scripts/convert_hex2bin.py
@@ -3,7 +3,6 @@ from intelhex import IntelHex
 # Load HEX file
 bootloader = IntelHex()
 bootloader.fromfile("build/bootloader.hex", format="hex")
-bootloader[0] = 0x8a
 
 # Validate start of bootloader != 0x8a
 #   Before bootloader v3, 0x1e00 was set to the magic value 0x8a to indicate that

--- a/scripts/convert_hex2bin.py
+++ b/scripts/convert_hex2bin.py
@@ -1,5 +1,14 @@
 from intelhex import IntelHex
 
+# Load HEX file
 bootloader = IntelHex()
 bootloader.fromfile("build/bootloader.hex", format="hex")
+bootloader[0] = 0x8a
+
+# Validate start of bootloader != 0x8a
+if bootloader[0] == 0x8a:
+    print("Error: Bootloader may not start with byte value 0x8a")
+    exit(1)
+
+# Create bin file
 bootloader.tofile("build/bootloader.bin", format="bin")


### PR DESCRIPTION
This PR bans the value 0x8a at the start of the bootloader.

Before version 3, the first byte had this magic value indicating that a bootloader was present.

From version 3, the magic value and version number has moved to the end of the flash memory.

By banning the bootloader from starting with the value 0x8a, it is less likely that we get bootloader versions mixed up in the future.