### PR TITLE
New erase EEPROM feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@
 # Project Description
 
 The bootloader for the Commander X16 System Management Controller (SMC) enables users to update
-the SMC firmware straight from the computer without an external programmer.
+the SMC firmware directly from the computer without an external programmer.
 
 The SMC firmware handles power control, keyboard and mouse input, and LED states.
 
-The bootloader is a separate program stored at the end of the flash memory.
+The bootloader is a separate program stored at the end of the SMC flash memory.
 
 This document describes the inner workings of the bootloader, which is of most interest
 to those who make tools that use the bootloader.
@@ -54,7 +54,7 @@ Updating the SMC firmware involves the following steps:
 
 3. Commit the data packet.
 
-4. Repeat steps 2 and 3 until the whole firmware has been transmitted.
+4. Repeat steps 2 and 3 until all of the firmware has been transmitted.
 
 5. Send the reboot command to finish the update.
 
@@ -72,9 +72,9 @@ in all versions of the bootloader.
 
 2. Hold down the reset button as you connect the Commander X16 to
 mains power. This will enable the update mode on a system fully upgraded to
-bootloader v3. This method of initiating an update is referred to as the "fail-safe" 
-and is handled by the bootloader's main entry point at address 0x1e00. 
-More on that later on in this document.
+bootloader v3. This method of initiating an update is referred to as the 
+["fail-safe"](#fail-safe-bootloader-v3) and is handled by the bootloader's 
+main entry point at address 0x1e00. 
 
 What happens internally when enabling update mode differs between the
 bootloader versions.
@@ -84,23 +84,20 @@ of the SMC flash memory. This is used to link interrupt service handlers
 for hardware I2C and, in case of v2, reset. The firmware is in 
 a non-working state until the update has finished.
 
-Bootloader v3 doesn't use interrupt vectors, and doesn't need to change
-the first 64-byte page. No changes are made to the firmware just by 
-enabling update mode.
+Bootloader v3 doesn't use interrupt vectors for hardware I2C. 
+No changes are made to the firmware just by enabling update mode.
 
 
 ### Send Data Packets
 
 The new firmware is transmitted to the bootloader in data packets.
-Each packet holds eight bytes of firmware data and one checksum byte.
+Each packet holds eight bytes of firmware data and one checksum byte,
+a total of nine bytes.
 
 The checksum is the two's complement of the sum of the previous bytes
 within the packet.
 
 Use I2C command 0x80 (transmit) to send each byte including the checksum.
-
-All versions of the bootloader buffers the bytes received in the SMC's RAM
-until it can be written to flash.
 
 
 ### Commit Data Packets
@@ -128,7 +125,8 @@ including the first page. Before writing the first page, bootloader v3
 erases all of the old firmware, starting from the end. When updating the 
 first page, the bootloader moves the firmware's reset vector (address 0x0000) 
 to the EE_RDY vector (0x0012). The reset vector is changed to point to the 
-bootloader's main entry point. This is part of the bootloader's fail-safe mechanism.
+bootloader's main entry point. This is part of the bootloader's 
+[fail-safe](#fail-safe-bootloader-v3) mechanism.
 
 
 ### Reboot
@@ -145,18 +143,21 @@ What happens next differs between the bootloader versions.
 an infinite loop. You need to power cycle the system to start
 the computer after the update.
 
-- Bootloader v2 resets the SMC using the watchdog timer. After the
+- Bootloader v2 resets the SMC with the watchdog timer. After
 reset, execution starts with the reset vector at address 0x0000. When
 enabling update mode, this was set to jump to a function in the
 bootloader that writes the first 64-byte page to flash. The bootloader
 then jumps to the firmware's real reset vector, which effectively
-turns off the computer.
+turns off the computer. There is no need to power cycle the computer.
+You may just press the power button to turn it on again.
 
-- The "bad" bootloader v2 hangs before the watchdog reset, which
-results in the first 64-byte page not being updated. You can get past
-the problem by grounding the physical reset pin of the SMC.
+- The "bad" bootloader v2 enters an infinite loop just before the 
+watchdog reset, which results in the first 64-byte page not 
+being updated. You can get past the problem by grounding 
+the physical reset pin of the SMC. Instructions on how to do that
+are found [here](https://github.com/X16Community/x16-smc/blob/main/doc/update-with-bad-bootloader-v2.md).
 
-- Bootloader v3 resets the SMC using the watchdog timer. The
+- Bootloader v3 resets the SMC with the watchdog timer. The
 first 64-byte page was already written to flash when first received.
 
 
@@ -207,8 +208,13 @@ enabled if you use a release including bootloader v3.
 the bootloader to v3 and then you must also update the firmware. The
 fail-safe mechanism is not enabled if you only update the bootloader.
 
-The fail-safe relies on the reset vector (address 0x0000) jumping to
-the bootloader main entry point (address 0x1e00). 
+Go to the [SMC Update Guide](https://github.com/X16Community/x16-smc/blob/main/doc/update-guide.md) 
+for further instructions.
+
+When the fail-safe is enabled, the reset vector (address 0x0000) jumps to
+the bootloader's main entry point (address 0x1e00). The reset vector is
+called every time the SMC hardware is reset, for instance when
+you connect the Commander X16 to mains power.
 
 The main entry point checks if the reset button is being pressed. If
 so it enables the firmware update mode. If the button is not pressed
@@ -220,8 +226,8 @@ has been corrupted:
 
 - If the update procedure is interrupted during the firmware erase stage: Firmware
 erase starts from the last page. If interrupted during this stage,
-the reset vector at address 0x0000 is still unchanged and will be pointing
-to the bootloader's main entry point at address 0x1e00.
+the reset vector at address 0x0000 is still unchanged and will jump to
+the bootloader's main entry point at address 0x1e00.
 
 - If the update procedure is interrupted after the entire firmware has been erased but
 before writing any part of the new firmware to flash memory: When
@@ -236,18 +242,20 @@ firmware to flash memory: The first page written to flash memory
 holds the reset vector that jumps to the bootloader's main entry point making
 it possible to start the update procedure.
 
+
 ## Verifying the New Firmware
 
-Starting from bootloader v3 it is possible to verify the new firmware before 
-the reboot command. 
+From bootloader v3 it is possible to verify the update before reboot.
 
-The update program must first rewind the target address to 0x0000 using I2C command 0x84, 
-and may then read one byte at a time from the flash memory using I2C command 0x85.
+Before starting to verify, the update program must ensure that the entire firmware has been
+written to flash memory. The flash memory can only be updated one 64-byte page
+at a time. If the last page was only partially filled, the update program must
+transmit and commit blank data to fill the last page completely. That way you may
+ensure that all of the firmware has been written to flash memory.
 
-The SMC flash memory can only be updated one 64-byte page at a time.
-In order to successfully verify the update, the update program must first ensure
-that the last page was filled and committed. 
-If necessary, the update program must send blank data to fill the last page. 
+Verification starts by rewinding the target address to 0x0000 with I2C command
+0x84. The content of the flash memory may then be read one byte at a time
+with I2C command 0x85.
 
 
 # SMC Memory Map
@@ -297,9 +305,9 @@ The SMC bootloader is installed during manufacturing of the Commander X16.
 
 You need to install the bootloader yourself if:
 
-- you want to update the bootloader version,
-- the SMC has been replaced by a new chip, or
-- the SMC has been corrupted and needs to be reinstalled.
+- You want to update the bootloader version
+- The SMC has been replaced by a new chip
+- The SMC has been corrupted and needs to be reinstalled
 
 ## Updating the Bootloader from the Commander X16
 
@@ -369,7 +377,7 @@ Available since v1.
 
 After a data packet of 9 bytes has been transmitted it must be committed with this command. 
 
-The first commit will target flash memory address 0x0000. The target address is advanced by 8 bytes on each successful commit.
+The first commit will target flash memory address 0x0000. The target address is advanced 8 bytes on each successful commit.
 In bootloader v1 and v2, the first 64-byte page is held in RAM until the end of the update when it's written to flash.
 
 Note that the target address can be rewound to 0x0000 by command 0x84.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [How the Bootloader Works](#how-the-bootloader-works)
     - [Introduction](#introduction)
     - [Bootloader Entry Points](#bootloader-entry-points)
-    - [Transmitting the new Firmware](#transmitting-the-new-firmware)
+    - [Transmitting the New Firmware](#transmitting-the-new-firmware)
     - [Verifying the new Firmware](#verifying-the-new-firmware)
     - [Fail-Safe](#fail-safe)
 - [SMC Memory Map](#smc-memory-map)
@@ -28,10 +28,12 @@ This is a custom bootloader for the Commander X16 ATtiny861 based System Managem
 
 The bootloader makes it possible to update the SMC firmware from the Commander X16 without using an external programmer.
 
-The firmware is stored at the beginning of the flash memory and provides an interface to the PS/2 keyboard
-and mouse. It also handles the psysical push buttons and the LEDs of the system.
+The firmware is stored at the beginning of the flash memory (byte address 0x0000-0x1dff) and provides an interface to the PS/2 keyboard
+and mouse. It also handles the phsysical push buttons and the LEDs of the system.
 
-The bootloader is a separate program that is stored at the end of the flash memory.
+The bootloader is a separate program that is stored at the end of the flash memory (byte address 0x1e00-0x1fff).
+
+All addresses mentioned in thise document are byte addresses, unless otherwise specified.
 
 
 # How the Bootloader Works
@@ -48,11 +50,18 @@ The bootloader has two entry points: the main entry point at address 0x1e00, and
 
 ### Main Entry Point (0x1e00)
 
-The SMC is always running even if the computer is turned off. As soon as you connect the system to mains power, the SMC executes its reset
-procedure. That ends by calling the reset vector at address 0x0000. When the bootloader is installed, the reset vector always jumps to
-the bootloader main entry point at address 0x1e00.
+As soon as you connect the system to mains power, the SMC executes its reset procedure. That ends by calling the reset vector at address 0x0000. 
 
-The main entry checks if the reset button is being pressed. 
+Before bootloader v3 the reset vector pointed directly to firmware code.
+
+From bootloader v3 the reset vector jumps to the bootloader main entry point at address 0x1e00. If, however, an older version of the bootloader
+was installed, and the bootloader was upgraded to v3 using an in-system upgrade tool, the reset vector at address 0x0000 is not set to
+the main entry point until you also update the firmware. In that case the reset vector continues to point to firmware code, and the [fail-safe](#fail-safe) introduced in
+bootloader v3 is not enabled.
+
+The main entry point does the following when called.
+
+First it checks if the reset button is being pressed.
 
 If the button is pressed, the computer is turned on, and the SMC update procedure is started. This method of starting the bootloader, holding down the reset button while
 connecting the system to power, works in most situations even if the firmware has been bricked. Read more about that
@@ -63,13 +72,18 @@ If the reset button is not pressed, execution continues with the firmware's own 
 at address 0x0012 when updating the firmware using the bootloader. The EE_RDY vector is not used by standard Arduino libraries, and is
 used for the same purpose by Optiboot. The solution prevents using the EEPROM Ready interrupt in firmware code.
 
+Downgrading the bootloader from v3 requires special care if done with an in-system tool. You must ensure that the fail-safe is uninstalled by
+pointing the reset vector directly to firmware code. This can be done by first updating the bootloader and then the firmware without resetting the
+SMC in between. Downgrading the bootloader using in-system tools is a riskful operation that should be avoided unless you have access to an
+external programmer that can be used to unbrick the SMC.
+
 ### Start Update Entry Point (0x1e02)
 
 The start update entry point is to be called while the computer is running. The update
 procedure is started immediately after calling this entry point.
 
-A program running on the X16 cannot directly call the start update entry point. It must be done through
-a firmware command offset. Currently the firmware's command offset 0x8f does this.
+A program running on the X16 cannot directly call the start update entry point. To make the SMC jump to this entry point, 
+the X16 program have to send I2C command 0x8f (start bootloader).
 
 ## Transmitting the New Firmware
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ After all nine bytes of a packet have been transmitted to the bootloader,
 the packet must be committed. This is done with I2C command 0x81 (commit).
 
 The bootloader sends a response code indicating whether the command
-was successful or not. If the command failed, it is possible to resend the
+was successful or not. If the command failed, it is possible to resend
 the packet and commit it again.
 
 The internal flash address pointer is automatically incremented on each successful commit.
@@ -432,3 +432,9 @@ content of the flash memory after an update.
 
 Available since v3.
 
+## Command 0x86 = EEPROM erase request
+
+Requests that the EEPROM is erased at the end of the update if
+if bit 0 of the value is 1.
+
+Available since v4.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 The bootloader for the Commander X16 System Management Controller (SMC) enables users to update
 the SMC firmware straight from the computer without an external programmer.
 
-The SMC handles power control, keyboard and mouse input, and LED states.
+The SMC firmware handles power control, keyboard and mouse input, and LED states.
 
 The bootloader is a separate program stored at the end of the flash memory.
 
@@ -63,9 +63,9 @@ Updating the SMC firmware involves the following steps:
 
 There are two ways to enable the bootloader's firmware update mode.
 
-1. Send I2C command 0x8F while the Commander X16 is running. That
+1. Send I2C command 0x8f while the Commander X16 is running. That
 command is part of the SMC firmware (not the bootloader). It will call
-the start bootloader entry point at address 0x1e02 if you momentarily press
+the start update entry point at address 0x1e02 if you momentarily press
 both the power and reset buttons at the same time within approximately
 20 seconds. This method of enabling the update mode is supported 
 in all versions of the bootloader.
@@ -79,7 +79,7 @@ More on that later on in this document.
 What happens internally when enabling update mode differs between the
 bootloader versions.
 
-Bootloader v1 and v2 writes its own vectors to the first 64-byte page
+Bootloader v1 and v2 write their own vectors to the first 64-byte page
 of the SMC flash memory. This is used to link interrupt service handlers
 for hardware I2C and, in case of v2, reset. The firmware is in 
 a non-working state until the update has finished.
@@ -108,13 +108,13 @@ until it can be written to flash.
 After all nine bytes of a packet have been transmitted to the bootloader,
 the packet must be committed. This is done with I2C command 0x81 (commit).
 
-The bootloader sends a response code telling if the command
+The bootloader sends a response code indicating whether the command
 was successful or not. If the command failed, it is possible to resend the
 the packet and commit it again.
 
 The internal flash address pointer is automatically incremented on each successful commit.
 
-The SMC hardware can only write to the flash memory in whole 64-byte pages. The
+The SMC hardware can only write to the flash memory in full 64-byte pages. The
 received data is buffered in RAM until there is a full page that can
 be written to flash.
 
@@ -123,12 +123,12 @@ RAM instead of writing it to flash. As mentioned above, the first page
 holds vectors that are used by these bootloader versions. 
 The first page is written to flash at the end of the update procedure.
 
-Bootloader v3 writes each whole page to flash, including the first page. 
-Before writing the first page, bootloader v3 erases all of the old firmware, 
-starting from the end. When updating the first page, the bootloader
-moves the firmware's reset vector (address 0x0000) to the EE_RDY vector (0x0012).
-The reset vector is changed to point to the bootloader's main entry point. This
-is part of the bootloader's fail-safe mechanism.
+Bootloader v3 writes each full 64-byte page to flash in the order it's received, 
+including the first page. Before writing the first page, bootloader v3 
+erases all of the old firmware, starting from the end. When updating the 
+first page, the bootloader moves the firmware's reset vector (address 0x0000) 
+to the EE_RDY vector (0x0012). The reset vector is changed to point to the 
+bootloader's main entry point. This is part of the bootloader's fail-safe mechanism.
 
 
 ### Reboot
@@ -204,7 +204,7 @@ to bootloader v3. This can be done as follows:
 enabled if you use a release including bootloader v3.
 
 - When updating the SMC from the Commander X16, you must first update
-the bootloader to v3 and after that you must also update the firmware. The
+the bootloader to v3 and then you must also update the firmware. The
 fail-safe mechanism is not enabled if you only update the bootloader.
 
 The fail-safe relies on the reset vector (address 0x0000) jumping to
@@ -213,7 +213,7 @@ the bootloader main entry point (address 0x1e00).
 The main entry point checks if the reset button is being pressed. If
 so it enables the firmware update mode. If the button is not pressed
 it jumps to the firmware's original reset vector that is moved
-to the EE_RDY vector (address 0x0012) during the update.
+to the EE_RDY vector (address 0x0012) during an update with bootloader v3.
 
 The main entry point is accessible in most cases even if the firmware
 has been corrupted:
@@ -245,8 +245,8 @@ The update program must first rewind the target address to 0x0000 using I2C comm
 and may then read one byte at a time from the flash memory using I2C command 0x85.
 
 The SMC flash memory can only be updated one 64-byte page at a time.
-In order to successfully verify the update, the update program must ensure
-that the last page was filled and committed before starting the verification operation. 
+In order to successfully verify the update, the update program must first ensure
+that the last page was filled and committed. 
 If necessary, the update program must send blank data to fill the last page. 
 
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ During the update procedure, the new firmware is sent to the bootloader over I2C
 for checking the integrity of the received data, and for writing it to the flash memory.
 
 The transmission is divided into packets. Each packet consists of eight firmware bytes and one checksum byte. The
-checksum is the two's complement of the sum of the previous bytes in the packet. I2C command offset 0x80 is used
+checksum is the two's complement of the sum of the previous bytes in the packet. I2C command 0x80 is used
 to transmit each byte of a packet.
 
-After all nine bytes of a packet have been transmitted, the packet is committed with I2C command offset 0x81.
+After all nine bytes of a packet have been transmitted, the packet is committed with I2C command 0x81.
 
 Note that the SMC can only update the flash memory in whole pages of 64 bytes. The received
 bytes are buffered until there is a full page that can be written to flash memory.
@@ -108,7 +108,7 @@ When writing the first 64 bytes to flash memory, the bootloader takes these spec
 The update procedure continues by transmitting and committing packets until the whole firmware has been
 received by the bootloader.
 
-Finally, the update program must use I2C command offset 0x82 (reboot). This will
+Finally, the update program must use I2C command 0x82 (reboot). This will
 write any remaining buffered data to flash memory. The SMC is then reset, which turns off the computer.
 
 ### Example
@@ -145,8 +145,8 @@ Cmd | R/W | Data | Comment
 ## Verifying the New Firmware
 
 It is possible to verify the new firmware before the reboot command. The update program
-can rewind the target address to 0x0000 with I2C command offset 0x84, and read one byte
-at a time from the flash memory using I2C command offset 0x85.
+can rewind the target address to 0x0000 with I2C command 0x84, and read one byte
+at a time from the flash memory using I2C command 0x85.
 
 The SMC flash memory can only be updated one page at a time. A page is 64 bytes.
 In order to successfully verify the the update, the update program must ensure

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Available since v3.
 
 ## Command 0x86 = EEPROM erase request
 
-Requests that the EEPROM is erased at the end of the update if
+Requests that the EEPROM is erased at the end of the update
 if bit 0 of the value is 1.
 
 Available since v4.

--- a/README.md
+++ b/README.md
@@ -1,121 +1,183 @@
-# Purpose
+# Table of Contents
 
-A custom bootloader for the Commander X16 ATtiny861 based System Management Controller (SMC).
+- [Project Description](#project-description)
+- [How the Bootloader Works](#how-the-bootloader-works)
+    - [Introduction](#introduction)
+    - [Bootloader Entry Points](#bootloader-entry-points)
+    - [Transmitting the new Firmware](#transmitting-the-new-firmware)
+    - [Verifying the new Firmware](#verifying-the-new-firmware)
+    - [Fail-Safe](#fail-safe)
+- [SMC Memory Map](#smc-memory-map)
+- [Building the Project](#building-the-project)
+- [Installing the Bootloader](#installing-the-bootloader)
+    - [Overview](#overview)
+    - [In-System Update of the Bootloader](#in-system-update-of-the-bootloader)
+    - [Programming the SMC with an External Programmer](#programming-the-smc-with-an-external-programmer)
+    
+- [I2C API](#i2c-api)
+    - [Command 0x80 = Transmit (master write)](#command-0x80--transmit-master-write)
+    - [Command 0x81 = Commit (master read)](#command-0x81--commit-master-read)
+    - [Command 0x82 = Reboot (master write)](#command-0x82--reboot-master-write)
+    - [Command 0x83 = Get bootloader version (master read)](#command-0x83--get-bootloader-version-master-read)
+    - [Command 0x84 = Rewind target address (master write)](#command-0x84--rewind-target-address-master-write)
+    - [Command 0x85 = Read flash memory](#command-0x85--read-flash-memory)
 
-The bootloader makes it possible to update the SMC firmware from the Commander X16 without an external programmer.
+# Project Description
+
+This is a custom bootloader for the Commander X16 ATtiny861 based System Management Controller (SMC).
+
+The bootloader makes it possible to update the SMC firmware from the Commander X16 without using an external programmer.
+
+The firmware is stored at the beginning of the flash memory and provides an interface to the PS/2 keyboard
+and mouse. It also handles the psysical push buttons and the LEDs of the system.
+
+The bootloader is a separate program that is stored at the end of the flash memory.
 
 
-# How It Works
+# How the Bootloader Works
 
-## Firmware Update Process
+## Introduction
 
-The update process is started either by requesting the firmware to call
-the bootloader's start update function or by holding down the Reset button
-while connecting the computer to power. The latter is called a recovery
-update. Read more about that below.
+For detailed information on how to update the SMC firmware, go to the [SMC Update Guide](https://github.com/X16Community/x16-smc/blob/main/doc/update-guide.md).
 
-A firmware update program runs on the X16 and sends the new SMC firmware to
-the bootloader over I2C.
+This section describes the inner workings of the bootloader. The information is of most interest to those who write tools that use the bootloader.
 
-The bootloader is responsible for checking the integrity of the transmitted data 
-and for writing it to the flash memory of the SMC.
+## Bootloader Entry Points
 
-The transmission is divided into packets of nine bytes. A packet begins with
-eight firmware bytes. The last byte is a checksum, the 
-2's complement of the sum of the previous eight bytes in the packet. I2C command 
-offset 0x80 is used to transmit each byte of a packet.
+The bootloader has two entry points: the main entry point at address 0x1e00, and the start update entry point at address 0x1e02.
 
-A complete packet must committed using I2C command offset 0x81 before transmission
-of the next packet is started.
+### Main Entry Point (0x1e00)
 
-The update process continues by transmitting and committing packets until the whole
-firmware has been received by the bootloader.
+The SMC is always running even if the computer is turned off. As soon as you connect the system to mains power, the SMC executes its reset
+procedure. That ends by calling the reset vector at address 0x0000. When the bootloader is installed, the reset vector always jumps to
+the bootloader main entry point at address 0x1e00.
 
-The update program running on the X16 can optionally rewind the target address
-to 0x0000 using command 0x84 and use command 0x85 to read one byte at a time from
-the SMC flash memory. This can be used to verify the update.
+The main entry checks if the reset button is being pressed. 
 
-Finally, the update program must use command 0x82 to reset the SMC. This will
-write any remaining buffered data to flash memory and then turn off the computer.
+If the button is pressed, the computer is turned on, and the SMC update procedure is started. This method of starting the bootloader, holding down the reset button while
+connecting the system to power, works in most situations even if the firmware has been bricked. Read more about that
+under [fail-safe](#fail-safe). The update program running on the Commander X16 must be loaded and started without keyboard or mouse support, 
+which are not available while the bootloader is running. One option is to store the update program as an autostarting program on the SD card.
 
-The SMC can only update the flash memory in whole pages of 64 bytes. The committed
+If the reset button is not pressed, execution continues with the firmware's own reset vector. That vector is moved to the EE_RDY (EEPROM Ready) vector
+at address 0x0012 when updating the firmware using the bootloader. The EE_RDY vector is not used by standard Arduino libraries, and is
+used for the same purpose by Optiboot. The solution prevents using the EEPROM Ready interrupt in firmware code.
+
+### Start Update Entry Point (0x1e02)
+
+The start update entry point is to be called while the computer is running. The update
+procedure is started immediately after calling this entry point.
+
+A program running on the X16 cannot directly call the start update entry point. It must be done through
+a firmware command offset. Currently the firmware's command offset 0x8f does this.
+
+## Transmitting the New Firmware
+
+During the update procedure, the new firmware is sent to the bootloader over I2C. The bootloader is responsible
+for checking the integrity of the received data, and for writing it to the flash memory.
+
+The transmission is divided into packets. Each packet consists of eight firmware bytes and one checksum byte. The
+checksum is the two's complement of the sum of the previous bytes in the packet. I2C command offset 0x80 is used
+to transmit each byte of a packet.
+
+After all nine bytes of a packet have been transmitted, the packet is committed with I2C command offset 0x81.
+
+Note that the SMC can only update the flash memory in whole pages of 64 bytes. The received
 bytes are buffered until there is a full page that can be written to flash memory.
 
-On receiving the first full page (address 0x0000-0x003f), the bootloader takes
-these special actions:
+When writing the first 64 bytes to flash memory, the bootloader takes these special actions:
 
-- Erasing the firmware area of the flash memory (address 0x0000-0x1dff)
+- The firmware area is erased starting from the end.
+- The firmware's reset vector is moved to EE_RDY (address 0x0012).
+- The reset vector (address 0x0000) is replaced by a jump to the bootloader main entry point
 
-- Moving the firmware's reset vector (address 0x0000) to EE_RDY (address 0x0012)
+The update procedure continues by transmitting and committing packets until the whole firmware has been
+received by the bootloader.
 
-- Pointing the reset vector to the bootloader main vector (address 0x1e00)
+Finally, the update program must use I2C command offset 0x82 (reboot). This will
+write any remaining buffered data to flash memory. The SMC is then reset, which turns off the computer.
 
-The reason for this is explained in the SMC reset process below.
+### Example
+
+This is a simple example illustrating the communication between the Commander X16 and the bootloader
+during an update.
 
 
-## SMC Reset Process and Starting the Bootloader Recovery Update
+Cmd | R/W | Data | Comment
+----|-----|------|---------------------
+0x80 | W  | 0x01 | 1st packet, 1st byte
+0x80 | W  | 0x02 | 1st packet, 2nd byte
+0x80 | W  | 0x03 | 1st packet, 3rd byte
+0x80 | W  | 0x04 | 1st packet, 4th byte
+0x80 | W  | 0x05 | 1st packet, 5th byte
+0x80 | W  | 0x06 | 1st packet, 6th byte
+0x80 | W  | 0x07 | 1st packet, 7th byte
+0x80 | W  | 0x08 | 1st packet, 8th byte
+0x80 | W  | 0xdc | 1st packet, checksum
+0x81 | R  | 0x01 | Commit 1st packet, OK response
+...|
+0x80 | W  | 0x09 | nth packet, 1st byte
+0x80 | W  | 0x0a | nth packet, 2nd byte
+0x80 | W  | 0x0b | nth packet, 3rd byte
+0x80 | W  | 0x0c | nth packet, 4th byte
+0x80 | W  | 0x0d | nth packet, 5th byte
+0x80 | W  | 0x0e | nth packet, 6th byte
+0x80 | W  | 0x0f | nth packet, 7th byte
+0x80 | W  | 0x10 | nth packet, 8th byte
+0x80 | W  | 0x9c | nth packet, checksum
+0x81 | R  | 0x01 | Commit nth packet, OK response
+0x82 | W  | Any  | Reboot
 
-The SMC is reset when first connecting it to power or when 
-the reset pin (#10) is grounded. On reset, execution always starts from the reset 
-vector (address 0x0000).
+## Verifying the New Firmware
 
-When the bootloader is installed, the reset vector is set to jump to the bootloader main 
-function (address 0x1e00), as described above.
+It is possible to verify the new firmware before the reboot command. The update program
+can rewind the target address to 0x0000 with I2C command offset 0x84, and read one byte
+at a time from the flash memory using I2C command offset 0x85.
 
-The bootloader main function checks if the Reset button is being pressed.
-
-If the Reset button is not pressed, the bootloader jumps to
-the EE_RDY vector (address 0x0012). The firmware's original
-reset vector is moved here during the update process, as described above.
-
-If the button is pressed, the computer is powered on and the 
-update process is started. 
-
-The update process is usually started by the update program that runs
-on the X16 requesting the firmware to call bootloader address
-0x1e02. Starting the process by holding down the Reset button 
-is primarily intended for recovery of an inoperable (bricked)
-SMC.
-
+The SMC flash memory can only be updated one page at a time. A page is 64 bytes.
+In order to successfully verify the the update, the update program must ensure
+that the last page is filled before starting the verify operation. 
+If necessary, the update program must send blank data to fill the last page. 
+If this is not done, the bootloader will write the last page to flash memory not 
+until the reboot command.
 
 ## Fail-Safe
 
-The bootloader was designed to be fail-safe. In many
-cases the bootloader recovery update process can be started even if 
-the firmware is inoperable (bricked).
+The bootloader is designed to be fail-safe. In many
+cases the update procedure can be started even if 
+the firmware is bricked:
 
-The fail-safe was designed especially with these situations in mind:
-
-- Update process interrupted during the firmware erase stage: Firmware
+- The update procedure is interrupted during the firmware erase stage: Firmware
 erase starts from the last page. If interrupted during this stage,
-the reset vector at address 0x0000 is still unchanged, and a
-recovery update is possible.
+the reset vector at address 0x0000 is still unchanged. The update
+procedure can be started by holding down reset when connecting the system
+to power.
 
-- Update process interrupted after the whole firmware has been erased but
+- The update procedure is interrupted after the whole firmware has been erased but
 before writing any parts of the new firmware to flash memory: When
-erasing the flash memory all words are set to byte value 0xffff, 
+erasing the flash memory, all words are set to byte value 0xffff, 
 which is interpreted as No Operation (NOP) by the SMC hardware. Execution
 starts from the reset vector at 0x0000 and continues until
-the first non NOP instruction at 0x1e00, the bootloader main function.
-This makes it possible to start the recovery update in this situation.
+the first non-NOP instruction at 0x1e00, the bootloader main function.
+This makes it possible to start the update procedure in this situation.
 
-- Update process interrupted after writing parts of the new
+- The update procedure is interrupted after writing parts of the new
 firmware to flash memory: The first page written to flash memory
 holds the reset vector that jumps to the bootloader main function making
-it possible to start the recovery update.
+it possible to start the update procedure.
 
 
-## SMC Memory Map
+# SMC Memory Map
 
 | Byte address  | Size        | Description                |
 |-------------- |-------------| ---------------------------|
-| 0x0000-0x1DFF | 7,680 bytes | Firmware area              |
+| 0x0000-0x1dff | 7,680 bytes | Firmware area              |
 | 0x0000        | 2 bytes     | Reset vector               |
 | 0x0012        | 2 bytes     | EE_RDY vector              |
-| 0x1E00-0x1FFF | 512 bytes   | Bootloader area            |
-| 0x1E00        | 2 bytes     | Bootloader main vector     |
-| 0x1E02        | 2 bytes     | Start update vector        |
-| 0x1FFE        | 2 bytes     | Bootloader version         |   
+| 0x1e00-0x1fff | 512 bytes   | Bootloader area            |
+| 0x1e00        | 2 bytes     | Bootloader main entry      |
+| 0x1e02        | 2 bytes     | Start update entry         |
+| 0x1ffe        | 2 bytes     | Bootloader version         |   
 
 
 # Building the Project
@@ -130,12 +192,35 @@ Build dependencies:
 
 - Python 3
 
-- Python intelhex module, install with pip intelhex
+- Python intelhex module, install with ```pip install intelhex```
 
-The bootloader is also automatically built by a Github action.
+The bootloader is also automatically built by a GitHub action.
 
+# Installing the Bootloader
 
-# Fuse Settings
+## Overview
+The SMC bootloader is installed during manufacturing of the Commander X16.
+
+You need to install the bootloader yourself if:
+
+- you want to update the bootloader version,
+- the SMC is replaced by a new chip, or
+- the SMC has been corrupted and needs to be reinstalled.
+
+## In-System Update of the Bootloader
+
+If you already have a functioning system, it is possible to do an
+in-system update of the bootloader without an external programmer.
+
+Instructions on how to do that are found [here](https://github.com/X16Community/x16-smc/blob/main/doc/smc-bootloader-tools.md).
+
+## Programming the SMC with an External Programmer
+
+It is always possible to install the bootloader using an External Programmer. Usually
+you install a packet that contains both the SMC firmware and the bootloader. Such packets are
+available from the [X16-SMC release page](https://github.com/X16Community/x16-smc/releases).
+
+### Fuse Settings
 
 The bootloader and the SMC firmware depend on several ATtiny fuse settings as set out below.
 
@@ -145,20 +230,16 @@ The recommended high fuse value is 0xD4. This enables Brown-out Detection at 4.3
 
 Finally, the extended fuse value must be 0xFE to enable self-programming of the flash memory. The bootloader cannot work without this setting.
 
+### Programming with avrdude
 
-# Initial Programming of the SMC with Avrdude
+Avrdude is the recommended software to use when programming the SMC using an external programmer.
 
-The initial programming of the SMC is done with an external programmer.
-
-The command line utility avrdude is the recommended tool together
-with a programmer that is compatible with avrdude.
-
-Example 1. Set fuses
+Example 1: Set fuses
 ```
 avrdude -cstk500v1 -Cavrdude.conf -pattiny861 -P<your port> -b19200 -Ulfuse:w:0xF1:m -Uhfuse:w:0xD4:m -Uefuse:w:0xFE:m
 ```
 
-Example 2. Write to flash
+Example 2: Write to flash
 ```
 avrdude -cstk500v1 -Cavrdude.conf -pattiny861 -P<your port> -b19200 -Uflash:w:build/firmware_with_bootloader.hex:i
 ```
@@ -171,11 +252,11 @@ The -P option selects port name on the host computer.
 
 The -b option sets transmission baudrate; 19200 is a good value.
 
-The -U option performs a memory operation. "-U flash:w:filename:i" writes to flash memory. "-U lfuse:w:0xF1:m" writes the low fuse value.
+The -U option performs a memory programming operation. "-U flash:w:filename:i" writes to flash memory. "-U lfuse:w:0xF1:m" writes the low fuse value.
 
-Please note that some fuse settings may cause the ATtiny861 not to respond. Resetting might require equipment for high voltage programming. Be careful if you choose not to use the recommended values.
+Please note that some fuse settings may cause the ATtiny861 not to respond. Resetting might require equipment for high voltage programming. Using non-recommended fuse settings may brick the device.
 
-The Arduino IDE also uses avrdude in the background. If you have installed the IDE you may enable verbose output and see what parameters are used by the IDE when it starts avrdude.
+The Arduino IDE also uses avrdude in the background. If you have installed the IDE you may enable verbose output and see what parameters are used by the IDE when it calls avrdude.
 
 
 # I2C API
@@ -204,7 +285,7 @@ Value | Description
 4     | Reserved
 5     | Error, overwriting bootloader section
 
-The firmware flash memory is erased on the 8th successful commit, just before writing the first 64 bytes to flash memory.
+The firmware flash memory area is erased during the 8th successful commit, just before writing the first 64-byte page to flash.
 
 ## Command 0x82 = Reboot (master write)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and mouse. It also handles the phsysical push buttons and the LEDs of the system
 
 The bootloader is a separate program that is stored at the end of the flash memory (byte address 0x1e00-0x1fff).
 
-All addresses mentioned in thise document are byte addresses, unless otherwise specified.
+All addresses mentioned in this document are byte addresses, unless otherwise specified.
 
 
 # How the Bootloader Works

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [Building the Project](#building-the-project)
 - [Installing the Bootloader](#installing-the-bootloader)
     - [Overview](#overview)
-    - [In-System Update of the Bootloader](#in-system-update-of-the-bootloader)
+    - [Updating the Bootloader from the Commander X16](#updating-the-bootloader-from-the-commander-x16)
     - [Programming the SMC with an External Programmer](#programming-the-smc-with-an-external-programmer)
     
 - [I2C API](#i2c-api)
@@ -55,9 +55,9 @@ As soon as you connect the system to mains power, the SMC executes its reset pro
 Before bootloader v3 the reset vector pointed directly to firmware code.
 
 From bootloader v3 the reset vector jumps to the bootloader main entry point at address 0x1e00. If, however, an older version of the bootloader
-was installed, and the bootloader was upgraded to v3 using an in-system upgrade tool, the reset vector at address 0x0000 is not set to
-the main entry point until you also update the firmware. In that case the reset vector continues to point to firmware code, and the [fail-safe](#fail-safe) introduced in
-bootloader v3 is not enabled.
+was installed, and the bootloader was upgraded to v3, the reset vector at address 0x0000 is not set to
+the main entry point unless you also update the firmware. If you only update the bootloader, the reset vector continues to point to 
+firmware code and the [fail-safe](#fail-safe) introduced in bootloader v3 is not enabled.
 
 The main entry point does the following when called.
 
@@ -72,10 +72,10 @@ If the reset button is not pressed, execution continues with the firmware's own 
 at address 0x0012 when updating the firmware using the bootloader. The EE_RDY vector is not used by standard Arduino libraries, and is
 used for the same purpose by Optiboot. The solution prevents using the EEPROM Ready interrupt in firmware code.
 
-Downgrading the bootloader from v3 requires special care if done with an in-system tool. You must ensure that the fail-safe is uninstalled by
-pointing the reset vector directly to firmware code. This can be done by first updating the bootloader and then the firmware without resetting the
-SMC in between. Downgrading the bootloader using in-system tools is a riskful operation that should be avoided unless you have access to an
-external programmer that can be used to unbrick the SMC.
+Downgrading the bootloader from v3 to an earlier version requires special care if done through software running on the Commander X16. 
+You must ensure that the fail-safe is uninstalled by pointing the reset vector directly to firmware code. This can be done by first 
+updating the bootloader and then the firmware without resetting the SMC in between. Downgrading the bootloader this way is
+a riskful operation that should be avoided unless you have access to an external programmer that can be used to unbrick the SMC.
 
 ### Start Update Entry Point (0x1e02)
 
@@ -168,7 +168,7 @@ procedure can be started by holding down reset when connecting the system
 to power.
 
 - The update procedure is interrupted after the whole firmware has been erased but
-before writing any parts of the new firmware to flash memory: When
+before writing any part of the new firmware to flash memory: When
 erasing the flash memory, all words are set to byte value 0xffff, 
 which is interpreted as No Operation (NOP) by the SMC hardware. Execution
 starts from the reset vector at 0x0000 and continues until
@@ -221,10 +221,10 @@ You need to install the bootloader yourself if:
 - the SMC is replaced by a new chip, or
 - the SMC has been corrupted and needs to be reinstalled.
 
-## In-System Update of the Bootloader
+## Updating the Bootloader from the Commander X16
 
-If you already have a functioning system, it is possible to do an
-in-system update of the bootloader without an external programmer.
+If you already have a functioning system, it is possible to update
+the bootloader from Commander X16 without an external programmer.
 
 Instructions on how to do that are found [here](https://github.com/X16Community/x16-smc/blob/main/doc/smc-bootloader-tools.md).
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Table of Contents
 
 - [Project Description](#project-description)
-- [How the Bootloader Works](#how-the-bootloader-works)
-    - [Introduction](#introduction)
-    - [Bootloader Entry Points](#bootloader-entry-points)
-    - [Transmitting the New Firmware](#transmitting-the-new-firmware)
-    - [Verifying the new Firmware](#verifying-the-new-firmware)
-    - [Fail-Safe](#fail-safe)
+- [Update Procedure](#update-procedure)
+    - [Overview](#overview)
+    - [Enable Firmware Update Mode](#enable-firmware-update-mode)
+    - [Send Data Packets](#send-data-packets)
+    - [Commit Data Packets](#commit-data-packets)
+    - [Reboot](#reboot)
+    - [Example](#example)
+- [Fail-Safe (Bootloader v3)](#fail-safe-bootloader-v3)
+- [Verifying the New Firmware](#verifying-the-new-firmware)
 - [SMC Memory Map](#smc-memory-map)
 - [Building the Project](#building-the-project)
 - [Installing the Bootloader](#installing-the-bootloader)
-    - [Overview](#overview)
+    - [Overview](#overview-1)
     - [Updating the Bootloader from the Commander X16](#updating-the-bootloader-from-the-commander-x16)
     - [Programming the SMC with an External Programmer](#programming-the-smc-with-an-external-programmer)
-    
 - [I2C API](#i2c-api)
     - [Command 0x80 = Transmit (master write)](#command-0x80--transmit-master-write)
     - [Command 0x81 = Commit (master read)](#command-0x81--commit-master-read)
@@ -24,98 +26,143 @@
 
 # Project Description
 
-This is a custom bootloader for the Commander X16 ATtiny861 based System Management Controller (SMC).
+The bootloader for the Commander X16 System Management Controller (SMC) enables users to update
+the SMC firmware straight from the computer without an external programmer.
 
-The bootloader makes it possible to update the SMC firmware from the Commander X16 without using an external programmer.
+The SMC handles power control keyboard and mouse input, and LED states.
 
-The firmware is stored at the beginning of the flash memory (byte address 0x0000-0x1dff) and provides an interface to the PS/2 keyboard
-and mouse. It also handles the phsysical push buttons and the LEDs of the system.
+The bootloader is a separate program stored at the end of the flash memory.
 
-The bootloader is a separate program that is stored at the end of the flash memory (byte address 0x1e00-0x1fff).
+This document describes the inner workings of the bootloader, which is of most interest
+to those who make tools that use the bootloader.
+
+For detailed information on how to update the SMC firmware, 
+check out the [SMC Update Guide](https://github.com/X16Community/x16-smc/blob/main/doc/update-guide.md).
 
 All addresses mentioned in this document are byte addresses, unless otherwise specified.
 
 
-# How the Bootloader Works
+## Update Procedure
 
-## Introduction
+### Overview
 
-For detailed information on how to update the SMC firmware, go to the [SMC Update Guide](https://github.com/X16Community/x16-smc/blob/main/doc/update-guide.md).
+Updating the SMC firmware involves the following steps:
 
-This section describes the inner workings of the bootloader. The information is of most interest to those who write tools that use the bootloader.
+1. Enable the bootloader's firmware update mode.
 
-## Bootloader Entry Points
+2. Send a data packet containing new firmware.
 
-The bootloader has two entry points: the main entry point at address 0x1e00, and the start update entry point at address 0x1e02.
+3. Commit the data packet.
 
-### Main Entry Point (0x1e00)
+4. Repeat steps 2 and 3 until the whole firmware has been transmitted.
 
-As soon as you connect the system to mains power, the SMC executes its reset procedure. That ends by calling the reset vector at address 0x0000. 
+5. Send the reboot command to finish the update.
 
-Before bootloader v3 the reset vector pointed directly to firmware code.
 
-From bootloader v3 the reset vector jumps to the bootloader main entry point at address 0x1e00. If, however, an older version of the bootloader
-was installed, and the bootloader was upgraded to v3, the reset vector at address 0x0000 is not set to
-the main entry point unless you also update the firmware. If you only update the bootloader, the reset vector continues to point to 
-firmware code and the [fail-safe](#fail-safe) introduced in bootloader v3 is not enabled.
+### Enable Firmware Update Mode
 
-The main entry point does the following when called.
+There are two ways to enable the bootloader's firmware update mode.
 
-First it checks if the reset button is being pressed.
+1. Send I2C command 0x8F while the Commander X16 is running. That
+command is part of the SMC firmware (not the bootloader). It will call
+the start bootloader entry point at address 0x1e02 if you momentarily press
+both the power and reset buttons at the same time within approximately
+20 seconds. This method of enabling the update mode is supported 
+in all versions of the bootloader.
 
-If the button is pressed, the computer is turned on, and the SMC update procedure is started. This method of starting the bootloader, holding down the reset button while
-connecting the system to power, works in most situations even if the firmware has been bricked. Read more about that
-under [fail-safe](#fail-safe). The update program running on the Commander X16 must be loaded and started without keyboard or mouse support, 
-which are not available while the bootloader is running. One option is to store the update program as an autostarting program on the SD card.
+2. Hold down the reset button as you connect the Commander X16 to
+mains power. This will enable the update mode on a system fully upgraded to
+bootloader v3. This method of initiating an update is referred to as the "fail-safe" 
+and is handled by the bootloader's main entry point at address 0x1e00. 
+More on that later on in this document.
 
-If the reset button is not pressed, execution continues with the firmware's own reset vector. That vector is moved to the EE_RDY (EEPROM Ready) vector
-at address 0x0012 when updating the firmware using the bootloader. The EE_RDY vector is not used by standard Arduino libraries, and is
-used for the same purpose by Optiboot. The solution prevents using the EEPROM Ready interrupt in firmware code.
+What happens internally when enabling update mode differs between the
+bootloader versions.
 
-Downgrading the bootloader from v3 to an earlier version requires special care if done through software running on the Commander X16. 
-You must ensure that the fail-safe is uninstalled by pointing the reset vector directly to firmware code. This can be done by first 
-updating the bootloader and then the firmware without resetting the SMC in between. Downgrading the bootloader this way is
-a riskful operation that should be avoided unless you have access to an external programmer that can be used to unbrick the SMC.
+Bootloader v1 and v2 writes its own vectors to the first 64 byte page
+of the SMC flash memory. This is used to link interrupt service handlers
+for hardware I2C and, in case of v2, reset. The firmware is in 
+a non-working state until the update has finished.
 
-### Start Update Entry Point (0x1e02)
+Bootloader v3 doesn't use interrupt vectors, and doesn't need to change
+the first 64 byte page. No changes are made to the firmware just by 
+enabling update mode.
 
-The start update entry point is to be called while the computer is running. The update
-procedure is started immediately after calling this entry point.
 
-A program running on the X16 cannot directly call the start update entry point. To make the SMC jump to this entry point, 
-the X16 program have to send I2C command 0x8f (start bootloader).
+### Send Data Packets
 
-## Transmitting the New Firmware
+The new firmware is transmitted from to the bootloader in data packets.
+Each packet holds eight bytes of firmware data and one checksum byte.
 
-During the update procedure, the new firmware is sent to the bootloader over I2C. The bootloader is responsible
-for checking the integrity of the received data, and for writing it to the flash memory.
+The checksum is the two's complement of the sum of the previous bytes
+within the packet.
 
-The transmission is divided into packets. Each packet consists of eight firmware bytes and one checksum byte. The
-checksum is the two's complement of the sum of the previous bytes in the packet. I2C command 0x80 is used
-to transmit each byte of a packet.
+Use I2C command 0x80 (transmit) to send each byte including the checksum.
 
-After all nine bytes of a packet have been transmitted, the packet is committed with I2C command 0x81.
+All versions of the bootloader buffers the bytes received in the SMC's RAM
+until it can be written to flash.
 
-Note that the SMC can only update the flash memory in whole pages of 64 bytes. The received
-bytes are buffered until there is a full page that can be written to flash memory.
 
-When writing the first 64 bytes to flash memory, the bootloader takes these special actions:
+### Commit Data Packets
 
-- The firmware area is erased starting from the end.
-- The firmware's reset vector is moved to EE_RDY (address 0x0012).
-- The reset vector (address 0x0000) is replaced by a jump to the bootloader main entry point
+After all nine bytes of a packet have been transmitted to the bootloader,
+the packet must be committed. This is done with I2C command 0x81 (commit).
 
-The update procedure continues by transmitting and committing packets until the whole firmware has been
-received by the bootloader.
+The bootloader sends a response code telling if the command
+was succesful or not. If the command failed, it is possible to resend the
+the packet and commit it again.
 
-Finally, the update program must use I2C command 0x82 (reboot). This will
-write any remaining buffered data to flash memory. The SMC is then reset, which turns off the computer.
+The internal flash address pointer is automatically incremented on each successful commit.
+
+The SMC hardware can only write to the flash memory in whole 64 byte pages. The
+received data is buffered in RAM until there is a full page that can
+be written to flash.
+
+Bootloader v1 and v2 keeps the new firmware for the first 64 byte page in
+RAM instead of writing it to flash. As mentioned above, the first page 
+holds vectors that are used by these bootloader versions. 
+The first page is written to flash at the end of the update procedure.
+
+Bootloader v3 writes each whole page to flash, including the first page. 
+Before writing the first page, bootloader v3 erases all of the old firmware, 
+starting from the end. When updating the first page, the bootloader
+moves the firmware's reset vector (address 0x0000) to the EE_RDY vector (0x0012).
+The reset vector is changed to point to the bootloader's main entry point.
+
+
+### Reboot
+
+After all of the new firmware has been transmitted and committed, send
+I2C command 0x82 (reboot) to finish the update.
+
+The reboot command writes any buffered data to the current
+64 byte page.
+
+What happens next differs between the bootloader versions.
+
+- Bootloader v1 writes the first 64 byte page to flash and enters
+an infinite loop. You need to power cycle the system to start
+the computer after the update.
+
+- Bootloader v2 resets the SMC using the watchdog timer. After the
+reset, execution starts with the reset vector at address 0x0000. When
+enabling update mode, this was set to jump to a function in the
+bootloader that writes the first 64 byte page to flash. The bootloader
+then jumps to the firmware's real reset vector, which effectively
+turns off the computer.
+
+- The "bad" bootloader v2 hangs before the watchdog reset, which
+results in not updating the first 64 byte page. You can get past
+the problem by grounding the physical reset pin of the SMC.
+
+- Bootloader v3 resets the SMC using the watchdog timer. The
+first 64 byte page was already written to flash when first received.
+
 
 ### Example
 
-This is a simple example illustrating the communication between the Commander X16 and the bootloader
+This is a simple example of communication between the Commander X16 and the bootloader
 during an update.
-
 
 Cmd | R/W | Data | Comment
 ----|-----|------|---------------------
@@ -129,7 +176,7 @@ Cmd | R/W | Data | Comment
 0x80 | W  | 0x08 | 1st packet, 8th byte
 0x80 | W  | 0xdc | 1st packet, checksum
 0x81 | R  | 0x01 | Commit 1st packet, OK response
-...|
+...
 0x80 | W  | 0x09 | nth packet, 1st byte
 0x80 | W  | 0x0a | nth packet, 2nd byte
 0x80 | W  | 0x0b | nth packet, 3rd byte
@@ -142,46 +189,82 @@ Cmd | R/W | Data | Comment
 0x81 | R  | 0x01 | Commit nth packet, OK response
 0x82 | W  | Any  | Reboot
 
-## Verifying the New Firmware
 
-It is possible to verify the new firmware before the reboot command. The update program
-can rewind the target address to 0x0000 with I2C command 0x84, and read one byte
-at a time from the flash memory using I2C command 0x85.
+## Fail-Safe (Bootloader v3)
 
-The SMC flash memory can only be updated one page at a time. A page is 64 bytes.
-In order to successfully verify the the update, the update program must ensure
-that the last page is filled before starting the verify operation. 
-If necessary, the update program must send blank data to fill the last page. 
-If this is not done, the bootloader will write the last page to flash memory not 
-until the reboot command.
+Bootloader v3 introduces a fail-safe mechanism that allows entering 
+update mode by holding the reset button on power-up, even if the 
+main firmware is corrupted.
 
-## Fail-Safe
+The fail-safe mechanism requires that you have a system fully upgraded
+to bootloader v3. This can be done as follows:
 
-The bootloader is designed to be fail-safe. In many
-cases the update procedure can be started even if 
-the firmware is bricked:
+- When updating the SMC with an external programmer, the fail-safe is
+enabled if you use a release including bootloader v3.
 
-- The update procedure is interrupted during the firmware erase stage: Firmware
+- When updating the SMC from the Commander X16, you must first update
+the bootloader to v3 and after that you must also update the firmware. The
+fail-safe mechanism is not enabled if you only update the bootloader.
+
+The fail-safe means that the update procedure can
+be started even if the firmware is bricked, for instance due to an
+aborted or failed update.
+
+It works as follows:
+
+- If the update procedure is interrupted during the firmware erase stage: Firmware
 erase starts from the last page. If interrupted during this stage,
-the reset vector at address 0x0000 is still unchanged. The update
-procedure can be started by holding down reset when connecting the system
-to power.
+the reset vector at address 0x0000 is still unchanged and will be pointing
+to the bootloader's main entry point at address 0x1e00.
 
-- The update procedure is interrupted after the whole firmware has been erased but
+- If the update procedure is interrupted after the whole firmware has been erased but
 before writing any part of the new firmware to flash memory: When
 erasing the flash memory, all words are set to byte value 0xffff, 
 which is interpreted as No Operation (NOP) by the SMC hardware. Execution
 starts from the reset vector at 0x0000 and continues until
-the first non-NOP instruction at 0x1e00, the bootloader main function.
-This makes it possible to start the update procedure in this situation.
+the first non-NOP instruction at address 0x1e00, the bootloader's main entryp point.
+This makes it possible to start the update procedure in this situation as well.
 
-- The update procedure is interrupted after writing parts of the new
+- If the update procedure is interrupted after writing parts of the new
 firmware to flash memory: The first page written to flash memory
-holds the reset vector that jumps to the bootloader main function making
+holds the reset vector that jumps to the bootloader's main entry point making
 it possible to start the update procedure.
+
+The bootloader's main entry point runs every time the SMC is powered on if the
+fail-safe is enabled. It checks if the reset button is being pressed. If the button
+is pressed, firmware update mode is enabled.
+
+If the button is not pressed, the bootloader jumps to the firmware's original
+reset vector that was moved to the EE_RDY vector (address 0x0012) on updating the
+first 64 byte page.
+
+
+## Verifying the New Firmware
+
+Starting from bootloader v3 it is possible to verify the new firmware before 
+the reboot command. 
+
+The update program must first rewind the target address to 0x0000 using I2C command 0x84, 
+and may then read one byte at a time from the flash memory using I2C command 0x85.
+
+The SMC flash memory can only be updated one 64 byte page at a time.
+In order to successfully verify the update, the update program must ensure
+that the last page was filled and committed before starting the verify operation. 
+If necessary, the update program must send blank data to fill the last page. 
 
 
 # SMC Memory Map
+
+## Bootloader v1 and v2
+
+| Byte address  | Size        | Description                |
+|-------------- |-------------| ---------------------------|
+| 0x0000-0x1dff | 7,680 bytes | Firmware area              |
+| 0x1e00-0x1fff | 512 bytes   | Bootloader area            |
+| 0x1e00        | 2 bytes     | Bootloader version         |
+| 0x1e02        | 2 bytes     | Start update entry         |   
+
+## Bootloader v3
 
 | Byte address  | Size        | Description                |
 |-------------- |-------------| ---------------------------|
@@ -218,13 +301,13 @@ The SMC bootloader is installed during manufacturing of the Commander X16.
 You need to install the bootloader yourself if:
 
 - you want to update the bootloader version,
-- the SMC is replaced by a new chip, or
+- the SMC has been replaced by a new chip, or
 - the SMC has been corrupted and needs to be reinstalled.
 
 ## Updating the Bootloader from the Commander X16
 
 If you already have a functioning system, it is possible to update
-the bootloader from Commander X16 without an external programmer.
+the bootloader from the Commander X16 without an external programmer.
 
 Instructions on how to do that are found [here](https://github.com/X16Community/x16-smc/blob/main/doc/smc-bootloader-tools.md).
 
@@ -283,11 +366,16 @@ A packet consists of 8 bytes to be written to flash and 1 checksum byte.
 
 The checksum is the two's complement of the least significant byte of the sum of the previous bytes in the packet. The least significant byte of the sum of all 9 bytes in a packet will consequently always be 0.
 
+Available since v1.
+
 ## Command 0x81 = Commit (master read)
 
 After a data packet of 9 bytes has been transmitted it must be committed with this command. 
 
 The first commit will target flash memory address 0x0000. The target address is moved forward 8 bytes on each successful commit.
+In bootloader v1 and v2, the first 64 byte page is held in RAM until the end of the update when it's written to flash.
+
+Note that the target address can be rewinded to 0x0000 by command 0x84.
 
 The command returns 1 byte. The possible return values are:
 
@@ -299,7 +387,7 @@ Value | Description
 4     | Reserved
 5     | Error, overwriting bootloader section
 
-The firmware flash memory area is erased during the 8th successful commit, just before writing the first 64-byte page to flash.
+Available since v1.
 
 ## Command 0x82 = Reboot (master write)
 
@@ -307,23 +395,26 @@ The reboot command must always be called after the last packet
 has been committed. If not, the SMC may be left in an inoperable
 state.
 
-The command first writes any buffered data to flash.
+The reboot command ensures that any buffered firmware data is written
+to the flash memory.
 
-The bootloader then resets the SMC. The SMC reset shuts down the computer. It
-can be restarted by pressing the power button. It is not necessary to power cycle the system
-after an update.
+From bootloader v2, the command resets the SMC and the computer can
+be restarted by pressing the power button withoug power cycling the
+system as was required in v1.
+
+Available since v1.
 
 ## Command 0x83 = Get bootloader version (master read)
 
 This command returns the bootloader version.
 
-Available since bootloader v3.
+Available since v3.
 
 ## Command 0x84 = Rewind target address (master write)
 
 Rewinds the target address to 0.
 
-Available since bootloader v3.
+Available since  v3.
 
 ## Command 0x85 = Read flash memory
 
@@ -334,5 +425,5 @@ The target address is post-incremented one byte.
 This function is primarily intended to be used for verifying the
 content of the flash memory after an update.
 
-Available since bootloader v3.
+Available since v3.
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ More on that later on in this document.
 What happens internally when enabling update mode differs between the
 bootloader versions.
 
-Bootloader v1 and v2 writes its own vectors to the first 64 byte page
+Bootloader v1 and v2 writes its own vectors to the first 64-byte page
 of the SMC flash memory. This is used to link interrupt service handlers
 for hardware I2C and, in case of v2, reset. The firmware is in 
 a non-working state until the update has finished.
 
 Bootloader v3 doesn't use interrupt vectors, and doesn't need to change
-the first 64 byte page. No changes are made to the firmware just by 
+the first 64-byte page. No changes are made to the firmware just by 
 enabling update mode.
 
 
@@ -109,16 +109,16 @@ After all nine bytes of a packet have been transmitted to the bootloader,
 the packet must be committed. This is done with I2C command 0x81 (commit).
 
 The bootloader sends a response code telling if the command
-was succesful or not. If the command failed, it is possible to resend the
+was successful or not. If the command failed, it is possible to resend the
 the packet and commit it again.
 
 The internal flash address pointer is automatically incremented on each successful commit.
 
-The SMC hardware can only write to the flash memory in whole 64 byte pages. The
+The SMC hardware can only write to the flash memory in whole 64-byte pages. The
 received data is buffered in RAM until there is a full page that can
 be written to flash.
 
-Bootloader v1 and v2 keeps the new firmware for the first 64 byte page in
+Bootloader v1 and v2 keeps the new firmware for the first 64-byte page in
 RAM instead of writing it to flash. As mentioned above, the first page 
 holds vectors that are used by these bootloader versions. 
 The first page is written to flash at the end of the update procedure.
@@ -137,27 +137,27 @@ After all of the new firmware has been transmitted and committed, send
 I2C command 0x82 (reboot) to finish the update.
 
 The reboot command writes any buffered data to the current
-64 byte page.
+64-byte page.
 
 What happens next differs between the bootloader versions.
 
-- Bootloader v1 writes the first 64 byte page to flash and enters
+- Bootloader v1 writes the first 64-byte page to flash and enters
 an infinite loop. You need to power cycle the system to start
 the computer after the update.
 
 - Bootloader v2 resets the SMC using the watchdog timer. After the
 reset, execution starts with the reset vector at address 0x0000. When
 enabling update mode, this was set to jump to a function in the
-bootloader that writes the first 64 byte page to flash. The bootloader
+bootloader that writes the first 64-byte page to flash. The bootloader
 then jumps to the firmware's real reset vector, which effectively
 turns off the computer.
 
 - The "bad" bootloader v2 hangs before the watchdog reset, which
-results in not updating the first 64 byte page. You can get past
+results in the first 64-byte page not being updated. You can get past
 the problem by grounding the physical reset pin of the SMC.
 
 - Bootloader v3 resets the SMC using the watchdog timer. The
-first 64 byte page was already written to flash when first received.
+first 64-byte page was already written to flash when first received.
 
 
 ### Example
@@ -207,38 +207,34 @@ enabled if you use a release including bootloader v3.
 the bootloader to v3 and after that you must also update the firmware. The
 fail-safe mechanism is not enabled if you only update the bootloader.
 
-The fail-safe means that the update procedure can
-be started even if the firmware is bricked, for instance due to an
-aborted or failed update.
+The fail-safe relies on the reset vector (address 0x0000) jumping to
+the bootloader main entry point (address 0x1e00). 
 
-It works as follows:
+The main entry point checks if the reset button is being pressed. If
+so it enables the firmware update mode. If the button is not pressed
+it jumps to the firmware's original reset vector that is moved
+to the EE_RDY vector (address 0x0012) during the update.
+
+The main entry point is accessible in most cases even if the firmware
+has been corrupted:
 
 - If the update procedure is interrupted during the firmware erase stage: Firmware
 erase starts from the last page. If interrupted during this stage,
 the reset vector at address 0x0000 is still unchanged and will be pointing
 to the bootloader's main entry point at address 0x1e00.
 
-- If the update procedure is interrupted after the whole firmware has been erased but
+- If the update procedure is interrupted after the entire firmware has been erased but
 before writing any part of the new firmware to flash memory: When
 erasing the flash memory, all words are set to byte value 0xffff, 
 which is interpreted as No Operation (NOP) by the SMC hardware. Execution
 starts from the reset vector at 0x0000 and continues until
-the first non-NOP instruction at address 0x1e00, the bootloader's main entryp point.
+the first non-NOP instruction at address 0x1e00, the bootloader's main entry point.
 This makes it possible to start the update procedure in this situation as well.
 
 - If the update procedure is interrupted after writing parts of the new
 firmware to flash memory: The first page written to flash memory
 holds the reset vector that jumps to the bootloader's main entry point making
 it possible to start the update procedure.
-
-The bootloader's main entry point runs every time the SMC is powered on if the
-fail-safe is enabled. It checks if the reset button is being pressed. If the button
-is pressed, firmware update mode is enabled.
-
-If the button is not pressed, the bootloader jumps to the firmware's original
-reset vector that was moved to the EE_RDY vector (address 0x0012) on updating the
-first 64 byte page.
-
 
 ## Verifying the New Firmware
 
@@ -248,9 +244,9 @@ the reboot command.
 The update program must first rewind the target address to 0x0000 using I2C command 0x84, 
 and may then read one byte at a time from the flash memory using I2C command 0x85.
 
-The SMC flash memory can only be updated one 64 byte page at a time.
+The SMC flash memory can only be updated one 64-byte page at a time.
 In order to successfully verify the update, the update program must ensure
-that the last page was filled and committed before starting the verify operation. 
+that the last page was filled and committed before starting the verification operation. 
 If necessary, the update program must send blank data to fill the last page. 
 
 
@@ -315,14 +311,14 @@ Instructions on how to do that are found [here](https://github.com/X16Community/
 ## Programming the SMC with an External Programmer
 
 It is always possible to install the bootloader using an External Programmer. Usually
-you install a packet that contains both the SMC firmware and the bootloader. Such packets are
+you install a packet that contains both the SMC firmware and the bootloader. Such packages are
 available from the [X16-SMC release page](https://github.com/X16Community/x16-smc/releases).
 
 ### Fuse Settings
 
 The bootloader and the SMC firmware depend on several ATtiny fuse settings as set out below.
 
-The recommended low fuse value is 0xF1. This will run the SMC at 16 MHz.
+The recommended low fuse value is 0xF1. This configures the SMC to run at 16 MHz.
 
 The recommended high fuse value is 0xD4. This enables Brown-out Detection at 4.3V, which is necessary to prevent flash memory corruption when self-programming is enabled. Serial Programming should be enabled (bit 5) and external reset disable should not be selected (bit 7). These settings are necessary for programming the SMC with an external programmer.
 
@@ -373,10 +369,10 @@ Available since v1.
 
 After a data packet of 9 bytes has been transmitted it must be committed with this command. 
 
-The first commit will target flash memory address 0x0000. The target address is moved forward 8 bytes on each successful commit.
-In bootloader v1 and v2, the first 64 byte page is held in RAM until the end of the update when it's written to flash.
+The first commit will target flash memory address 0x0000. The target address is advanced by 8 bytes on each successful commit.
+In bootloader v1 and v2, the first 64-byte page is held in RAM until the end of the update when it's written to flash.
 
-Note that the target address can be rewinded to 0x0000 by command 0x84.
+Note that the target address can be rewound to 0x0000 by command 0x84.
 
 The command returns 1 byte. The possible return values are:
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ No changes are made to the firmware just by enabling update mode.
 
 ### Send Data Packets
 
-The new firmware is transmitted to the bootloader in data packets.
-Each packet holds eight bytes of firmware data and one checksum byte,
-a total of nine bytes.
+The new firmware is transmitted to the bootloader over the I2C bus. The
+transmission is divided into data packets. Each packet holds eight bytes 
+of firmware data and one checksum byte, a total of nine bytes.
 
 The checksum is the two's complement of the sum of the previous bytes
 within the packet.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 The bootloader for the Commander X16 System Management Controller (SMC) enables users to update
 the SMC firmware straight from the computer without an external programmer.
 
-The SMC handles power control keyboard and mouse input, and LED states.
+The SMC handles power control, keyboard and mouse input, and LED states.
 
 The bootloader is a separate program stored at the end of the flash memory.
 
@@ -91,7 +91,7 @@ enabling update mode.
 
 ### Send Data Packets
 
-The new firmware is transmitted from to the bootloader in data packets.
+The new firmware is transmitted to the bootloader in data packets.
 Each packet holds eight bytes of firmware data and one checksum byte.
 
 The checksum is the two's complement of the sum of the previous bytes
@@ -127,7 +127,8 @@ Bootloader v3 writes each whole page to flash, including the first page.
 Before writing the first page, bootloader v3 erases all of the old firmware, 
 starting from the end. When updating the first page, the bootloader
 moves the firmware's reset vector (address 0x0000) to the EE_RDY vector (0x0012).
-The reset vector is changed to point to the bootloader's main entry point.
+The reset vector is changed to point to the bootloader's main entry point. This
+is part of the bootloader's fail-safe mechanism.
 
 
 ### Reboot
@@ -399,7 +400,7 @@ The reboot command ensures that any buffered firmware data is written
 to the flash memory.
 
 From bootloader v2, the command resets the SMC and the computer can
-be restarted by pressing the power button withoug power cycling the
+be restarted by pressing the power button without power cycling the
 system as was required in v1.
 
 Available since v1.

--- a/command.inc
+++ b/command.inc
@@ -139,6 +139,38 @@ cmd_commit_exit:
 .endm
 
 ;******************************************************************************
+; Function...: CMD_EEPROM_ERASE
+; Description: Erases the entire EEPROM, 512 bytes
+; In.........: Nothing
+; Out........: Nothing
+.macro CMD_EEPROM_ERASE
+    ; Select erase command
+    ldi r16, (0<<EEPM1) | (1<<EEPM0)
+    out EECR, r16
+    
+    ; Setup start address to end of EEPROM (0x01ff)
+    ldi target_addrL, 0xff
+    ldi target_addrH, 0x01
+
+eeprom_erase2:
+    ; Wait for EEPROM ready
+    sbic EECR, EEPE
+    rjmp eeprom_erase2
+
+    ; Load EEPROM target address
+    out EEARL, target_addrL
+    out EEARH, target_addrH
+
+    ; Run erase command
+    sbi EECR, EEMPE
+    sbi EECR, EEPE
+
+    ; Decrement address, continue if not underflowing
+    sbiw target_addrL, 1
+    brcc eeprom_erase2
+.endm
+
+;******************************************************************************
 ; Function...: CMD_REBOOT
 ; Description: Writes remainging data in the buffer to flash and resets the SMC
 ; In.........: Nothing
@@ -150,13 +182,19 @@ cmd_commit_exit:
     rcall flash_write
 
 cmd_reboot2:
+    ; Erase EEPROM if requested
+    lsr eeprom_flag
+    brcc cmd_reboot3
+    CMD_EEPROM_ERASE
+
+cmd_reboot3:
     ; Set watchdog reset after 1 second
     ldi r16,(1<<WDE) | (0<<WDIE) | (0<<WDP3) | (1<<WDP2) | (1<<WDP1) | (0<<WDP0)
-    out WDTCR,r16
+    out WDTCR, r16
 
-cmd_reboot_3:
+cmd_reboot4:
     ; Wait here until reset
-    rjmp cmd_reboot_3
+    rjmp cmd_reboot4
 .endm
 
 ;******************************************************************************
@@ -190,3 +228,4 @@ cmd_reboot_3:
 .macro CMD_READ_FLASH
     lpm r17, Z+
 .endm
+

--- a/i2c.asm
+++ b/i2c.asm
@@ -171,16 +171,19 @@ i2c_receive:
     CMD_REBOOT                          ; Guaranteed not to return
 
 i2c_receive2:
+    ; Command 0x80 - Transmit data
     cpi i2c_command, 0x80
     brne i2c_receive3
     CMD_RECEIVE_PACKET
 
 i2c_receive3:
+    ; Command 0x84 - Rewind target address
     cpi i2c_command, 0x84
     brne i2c_receive4
     CMD_REWIND_TARGET_ADDR
 
 i2c_receive4:
+    ; Command 0x86 - EEPROM erase request
     cpi i2c_command, 0x86
     brne i2c_receive5
     mov eeprom_flag, r16

--- a/i2c.asm
+++ b/i2c.asm
@@ -181,9 +181,13 @@ i2c_receive3:
     CMD_REWIND_TARGET_ADDR
 
 i2c_receive4:
+    cpi i2c_command, 0x86
+    brne i2c_receive5
+    mov eeprom_flag, r16
+
+i2c_receive5:
     clr i2c_command
     rjmp i2c_send_ack
-
 
 ;******************************************************************************
 ; Function...: i2c_transmit

--- a/main.asm
+++ b/main.asm
@@ -58,7 +58,7 @@ main:
     ldi r16, 0
     out WDTCSR, r16
 
-    ; Configure Reset button pin (PB4) as input pullup
+    ; Configure Reset button pin as input pullup
     cbi DDRB, RESET_BTN
     sbi PORTB, RESET_BTN
     

--- a/main.asm
+++ b/main.asm
@@ -129,6 +129,7 @@ update_firmware:
     movw target_addrH:target_addrL, zeroH:zeroL
     clr packet_count
     clr chip_erased
+    clr eeprom_flag
 
     ; Start I2C
     rjmp i2c_main

--- a/registers.inc
+++ b/registers.inc
@@ -28,8 +28,9 @@
 .def packet_tailL                  = r2       ; Pointer to current RAM buffer tail
 .def packet_tailH                  = r3
 .def chip_erased                   = r4
+.def eeprom_flag                   = r5
 
-; r5-r13 free
+; r6-r13 free
 
 .def zeroL                         = r14
 .def zeroH                         = r15

--- a/version.asm
+++ b/version.asm
@@ -24,4 +24,4 @@
 
 .cseg
 .org 0xfff
-.db $8a, 03
+.db $8a, 04


### PR DESCRIPTION
This PR adds a new EEPROM erase feature.

An currently open PR to the x16-smc project makes it possible to write to and read from the EEPROM. If this feature is released, we could end up having data in the EEPROM that prevents booting the system. We can get out of such a situation by enabling the bootloader to erase the EEPROM.

The bootloader's default operation is still not to touch the EEPROM.

The new I2C command (0x86) lets you set a flag that determines whether or not the EEPROM is erased. If bit 0 of the flag is cleared (=0), the EEPROM is preserved, and if it is set (=1) the EEPROM is erased. After erasing the EEPROM, all addresses have the value 0xff.